### PR TITLE
New envelope zooming actions

### DIFF
--- a/Wol/wol.cpp
+++ b/Wol/wol.cpp
@@ -36,30 +36,43 @@ void SelectAllTracksExceptFolderParents(COMMAND_T* ct);
 static COMMAND_T g_commandTable[] =
 {
 //!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
-		{ { DEFACCEL, "SWS/wol: Set \"Vertical zoom center\" to \"Track at center of view\"" }, "WOL_SETVZOOMC_TRACKCVIEW", SetVerticalZoomCenter, NULL, 0},
-		{ { DEFACCEL, "SWS/wol: Set \"Vertical zoom center\" to \"Top visible track\"" }, "WOL_SETVZOOMC_TOPVISTRACK", SetVerticalZoomCenter, NULL, 1},
-		{ { DEFACCEL, "SWS/wol: Set \"Vertical zoom center\" to \"Last selected track\"" }, "WOL_SETVZOOMC_LASTSELTRACK", SetVerticalZoomCenter, NULL, 2},
-		{ { DEFACCEL, "SWS/wol: Set \"Vertical zoom center\" to \"Track under mouse cursor\"" }, "WOL_SETVZOOMC_TRACKMOUSECUR", SetVerticalZoomCenter, NULL, 3},
 
-		{ { DEFACCEL, "SWS/wol: Set \"Horizontal zoom center\" to \"Edit cursor or play cursor (default)\"" }, "WOL_SETHZOOMC_EDITPLAYCUR", SetHorizontalZoomCenter, NULL, 0},
-		{ { DEFACCEL, "SWS/wol: Set \"Horizontal zoom center\" to \"Edit cursor\"" }, "WOL_SETHZOOMC_EDITCUR", SetHorizontalZoomCenter, NULL, 1},
-		{ { DEFACCEL, "SWS/wol: Set \"Horizontal zoom center\" to \"Center of view\"" }, "WOL_SETHZOOMC_CENTERVIEW", SetHorizontalZoomCenter, NULL, 2},
-		{ { DEFACCEL, "SWS/wol: Set \"Horizontal zoom center\" to \"Mouse cursor\"" }, "WOL_SETHZOOMC_MOUSECUR", SetHorizontalZoomCenter, NULL, 3},
+	///////////////////////////////////////////////////////////////////////////////////////////////////
+	// Zoom
+	///////////////////////////////////////////////////////////////////////////////////////////////////
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Vertical zoom center\" to \"Track at center of view\"" }, "WOL_SETVZOOMC_TRACKCVIEW", SetVerticalZoomCenter, NULL, 0},
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Vertical zoom center\" to \"Top visible track\"" }, "WOL_SETVZOOMC_TOPVISTRACK", SetVerticalZoomCenter, NULL, 1},
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Vertical zoom center\" to \"Last selected track\"" }, "WOL_SETVZOOMC_LASTSELTRACK", SetVerticalZoomCenter, NULL, 2},
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Vertical zoom center\" to \"Track under mouse cursor\"" }, "WOL_SETVZOOMC_TRACKMOUSECUR", SetVerticalZoomCenter, NULL, 3},
+
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Horizontal zoom center\" to \"Edit cursor or play cursor (default)\"" }, "WOL_SETHZOOMC_EDITPLAYCUR", SetHorizontalZoomCenter, NULL, 0},
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Horizontal zoom center\" to \"Edit cursor\"" }, "WOL_SETHZOOMC_EDITCUR", SetHorizontalZoomCenter, NULL, 1},
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Horizontal zoom center\" to \"Center of view\"" }, "WOL_SETHZOOMC_CENTERVIEW", SetHorizontalZoomCenter, NULL, 2},
+		{ { DEFACCEL, "SWS/wol: Options - Set \"Horizontal zoom center\" to \"Mouse cursor\"" }, "WOL_SETHZOOMC_MOUSECUR", SetHorizontalZoomCenter, NULL, 3},
 
 		{ { DEFACCEL, "SWS/wol: Set selected envelope height to default" }, "WOL_SETSELENVHDEF", SetVerticalZoomSelectedEnvelope, NULL, 0 },
 		{ { DEFACCEL, "SWS/wol: Set selected envelope height to minimum" }, "WOL_SETSELENVHMIN", SetVerticalZoomSelectedEnvelope, NULL, 1 },
 		{ { DEFACCEL, "SWS/wol: Set selected envelope height to maximum" }, "WOL_SETSELENVHMAX", SetVerticalZoomSelectedEnvelope, NULL, 2 },
 		{ { DEFACCEL, "SWS/wol: Adjust selected envelope height (MIDI CC relative/mousewheel)" }, "WOL_ADJSELENVH", NULL, NULL, 0, NULL, 0, AdjustSelectedEnvelopeOrTrackHeight, },
-		{ { DEFACCEL, "SWS/wol: Adjust selected envelope or last touched track height (MIDI CC relative/mousewheel)" }, "WOL_ADJSELENVTRH", NULL, NULL, 1, NULL, 0, AdjustSelectedEnvelopeOrTrackHeight, },
+		{ { DEFACCEL, "SWS/wol: Adjust selected envelope height, zoom center to middle arrange (MIDI CC relative/mousewheel)" }, "WOL_ADJSELENVHZCMA", NULL, NULL, 1, NULL, 0, AdjustSelectedEnvelopeOrTrackHeight, },
+		{ { DEFACCEL, "SWS/wol: Adjust selected envelope height, zoom center to mouse cursor (MIDI CC relative/mousewheel)" }, "WOL_ADJSELENVHZCMC", NULL, NULL, 2, NULL, 0, AdjustSelectedEnvelopeOrTrackHeight, },
+		{ { DEFACCEL, "SWS/wol: Adjust selected envelope or last touched track height (MIDI CC relative/mousewheel)" }, "WOL_ADJSELENVTRH", NULL, NULL, 3, NULL, 0, AdjustSelectedEnvelopeOrTrackHeight, },
+		{ { DEFACCEL, "SWS/wol: Adjust selected envelope or last touched track height, zoom center to middle arrange (MIDI CC relative/mousewheel)" }, "WOL_ADJSELENVTRHZCMA", NULL, NULL, 4, NULL, 0, AdjustSelectedEnvelopeOrTrackHeight, },
+		{ { DEFACCEL, "SWS/wol: Adjust selected envelope or last touched track height, zoom center to mouse cursor (MIDI CC relative/mousewheel)" }, "WOL_ADJSELENVTRHZCMC", NULL, NULL, 5, NULL, 0, AdjustSelectedEnvelopeOrTrackHeight, },
 		{ { DEFACCEL, "SWS/wol: Adjust envelope or track height under mouse cursor (MIDI CC relative/mousewheel)" }, "WOL_ADJENVTRHMOUSE", NULL, NULL, 0, NULL, 0, AdjustEnvelopeOrTrackHeightUnderMouse, },
+		{ { DEFACCEL, "SWS/wol: Adjust envelope or track height under mouse cursor, zoom center to mouse cursor (MIDI CC relative/mousewheel)" }, "WOL_ADJENVTRHMOUSEZCMC", NULL, NULL, 2, NULL, 0, AdjustEnvelopeOrTrackHeightUnderMouse, },
 		{ { DEFACCEL, "SWS/wol: Toggle enable extended zoom for envelopes in track lane" }, "WOL_TENEXTZENVTRL", ToggleEnableEnvelopesExtendedZoom, NULL, 0, IsEnvelopesExtendedZoomEnabled },
 		{ { DEFACCEL, "SWS/wol: Toggle enable envelope overlap for envelopes in track lane" }, "WOL_TENENVOLENVTRL", ToggleEnableEnvelopeOverlap, NULL, 0, IsEnvelopeOverlapEnabled },
 		{ { DEFACCEL, "SWS/wol: Force overlap for selected envelope in track lane in its track height" }, "WOL_FENVOL", ForceEnvelopeOverlap, NULL, 0 },
 		{ { DEFACCEL, "SWS/wol: Restore previous envelope overlap settings" }, "WOL_RESENVOLSET", ForceEnvelopeOverlap, NULL, 1 },
-		{ { DEFACCEL, "SWS/wol: Horizontal zoom to selected envelope in time selection" }, "WOL_HZOOMSELENVTIMESEL", ZoomSelectedEnvelopeTimeSelection, NULL, 0 },
-		{ { DEFACCEL, "SWS/wol: Full zoom to selected envelope in time selection" }, "WOL_FZOOMSELENVTIMESEL", ZoomSelectedEnvelopeTimeSelection, NULL, 1 },
+		{ { DEFACCEL, "SWS/wol: Horizontal zoom selected envelope in time selection" }, "WOL_HZOOMSELENVTIMESEL", ZoomSelectedEnvelopeTimeSelection, NULL, 0 },
+		{ { DEFACCEL, "SWS/wol: Full zoom selected envelope in time selection" }, "WOL_FZOOMSELENVTIMESEL", ZoomSelectedEnvelopeTimeSelection, NULL, 1 },
 
+	///////////////////////////////////////////////////////////////////////////////////////////////////
+	// Track
+	///////////////////////////////////////////////////////////////////////////////////////////////////
 		{ { DEFACCEL, "SWS/wol: Select all tracks except folder parents" }, "WOL_SELTREXCFOLDPAR", SelectAllTracksExceptFolderParents, NULL },
+
 //!WANT_LOCALIZE_1ST_STRING_END
 
 		{ {}, LAST_COMMAND, },

--- a/Wol/wol_Util.h
+++ b/Wol/wol_Util.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include "../Breeder/BR_EnvelopeUtil.h"
+
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -35,21 +37,43 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 bool SaveSelectedTracks();
 bool RestoreSelectedTracks();
+
+/* refreshes UI too */
 void SetTrackHeight(MediaTrack* track, int height, bool useChunk = false);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-/// Tcp
+/// Arrange/TCP
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+enum VerticalZoomCenter
+{
+	CLIP_IN_ARRANGE = 0,		// Do not change order, add at the end
+	MID_ARRANGE,
+	MOUSE_CURSOR,
+	UPPER_HALF,
+	LOWER_HALF
+};
+
 int GetTcpEnvMinHeight();
 int GetTcpTrackMinHeight();
 int GetCurrentTcpMaxHeight();
-void ScrollToTrackEnvelopeIfNotInArrange(TrackEnvelope* envelope);
-void ScrollToTrackIfNotInArrange(TrackEnvelope* envelope);
+void SetArrangeScroll(int offsetY, int height, VerticalZoomCenter center = CLIP_IN_ARRANGE);
+void SetArrangeScrollTo(MediaTrack* track, VerticalZoomCenter center = CLIP_IN_ARRANGE);
+inline void SetArrangeScrollTo(MediaItem* item, VerticalZoomCenter center = CLIP_IN_ARRANGE);
+inline void SetArrangeScrollTo(MediaItem_Take* take, VerticalZoomCenter center = CLIP_IN_ARRANGE);
+void SetArrangeScrollTo(TrackEnvelope* envelope, bool check = true, VerticalZoomCenter center = CLIP_IN_ARRANGE);
+void SetArrangeScrollTo(BR_Envelope* envelope, VerticalZoomCenter center = CLIP_IN_ARRANGE);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// Envelope
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 int CountVisibleTrackEnvelopesInTrackLane(MediaTrack* track);
+
+/*  Return   -1 for envelope not in track lane or not visible, *laneCount and *envCount not modified
+			 0 for overlap disabled, *laneCount = *envCount = number of lanes (same as visible envelopes)
+			 1 for overlap enabled, envelope height < overlap limit -> single lane (one envelope visible), *laneCount = *envCount = 1
+			 2 for overlap enabled, envelope height < overlap limit -> single lane (overlapping), *laneCount = 1, *envCount = number of visible envelopes
+			 3 for overlap enabled, envelope height > overlap limit -> single lane (one envelope visible), *laneCount = *envCount = 1
+			 4 for overlap enabled, envelope height > overlap limit -> multiple lanes, *laneCount = *envCount = number of lanes (same as visible envelopes) */
 int GetEnvelopeOverlapState(TrackEnvelope* envelope, int* laneCount = NULL, int* envCount = NULL);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Wol/wol_Zoom.h
+++ b/Wol/wol_Zoom.h
@@ -30,18 +30,13 @@
 
 
 
-void wol_ZoomInit();
+void ToggleEnableEnvelopesExtendedZoom(COMMAND_T* = NULL);
+int IsEnvelopesExtendedZoomEnabled(COMMAND_T* = NULL);
 
 void AdjustSelectedEnvelopeOrTrackHeight(COMMAND_T* ct, int val, int valhw, int relmode, HWND hwnd);
 void AdjustEnvelopeOrTrackHeightUnderMouse(COMMAND_T* ct, int val, int valhw, int relmode, HWND hwnd);
 
 void SetVerticalZoomSelectedEnvelope(COMMAND_T* ct);
-
-void SetVerticalZoomCenter(COMMAND_T* ct);
-void SetHorizontalZoomCenter(COMMAND_T* ct);
-
-void ToggleEnableEnvelopesExtendedZoom(COMMAND_T* = NULL);
-int IsEnvelopesExtendedZoomEnabled(COMMAND_T* = NULL);
 
 void ToggleEnableEnvelopeOverlap(COMMAND_T* = NULL);
 int IsEnvelopeOverlapEnabled(COMMAND_T* = NULL);
@@ -49,3 +44,10 @@ int IsEnvelopeOverlapEnabled(COMMAND_T* = NULL);
 void ForceEnvelopeOverlap(COMMAND_T* ct);
 
 void ZoomSelectedEnvelopeTimeSelection(COMMAND_T* ct);
+
+void SetVerticalZoomCenter(COMMAND_T* ct);
+void SetHorizontalZoomCenter(COMMAND_T* ct);
+
+
+
+void wol_ZoomInit();

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,9 +1,13 @@
 New actions
 +Main:
  - SWS/BR: Options - Set "Run FX after stopping for" to x ms (various values)
+ - SWS/wol: Adjust selected envelope height, zoom center to middle arrange/mouse cursor (MIDI CC relative/mousewheel)
+ - SWS/wol: Adjust selected envelope or last touched track height, zoom center to middle arrange/mouse cursor (MIDI CC relative/mousewheel)
+ - SWS/wol: Adjust envelope or track height under mouse cursor, zoom center to mouse cursor (MIDI CC relative/mousewheel)
 
 Fixes
 +Issue 761: Obey preference for volume envelope scaling when creating volume send envelopes with various actions
++Renamed "SWS/wol: Set "Vertical/Horizontal zoom center" to..." actions to "SWS/wol: Options - Set "Vertical/Horizontal zoom center" to..." to be consistent with Breeder's actions.
 
 ReaScript
 +Added functions:


### PR DESCRIPTION
Renamed "SWS/wol: Set "Vertical/Horizontal zoom center" to..." actions to "SWS/wol: Options - Set "Vertical/Horizontal zoom center" to..." to be consistent with Breeder's actions.

New scrolling code in wol_Util.h with more options.

Added actions
 - SWS/wol: Adjust selected envelope height, zoom center to middle arrange/mouse cursor (MIDI CC relative/mousewheel)
 - SWS/wol: Adjust selected envelope or last touched track height, zoom center to middle arrange/mouse cursor (MIDI CC relative/mousewheel)
 - SWS/wol: Adjust envelope or track height under mouse cursor, zoom center to mouse cursor (MIDI CC relative/mousewheel)